### PR TITLE
C buffer overrun tweak

### DIFF
--- a/custom.py
+++ b/custom.py
@@ -15,7 +15,7 @@ with hid.Device(path=path) as h:
   print(f'Product: {h.product}')
   print(f'Serial Number: {h.serial}')
   while True:
-    msg = h.read(8).decode()
+    msg = h.read(7).decode()
     
     if msg.startswith("LAYER:"):
       layer = int(msg[6])

--- a/keymap.c
+++ b/keymap.c
@@ -234,7 +234,7 @@ uint32_t layer_state_set_user(uint32_t state) {
   ergodox_right_led_2_off();
   ergodox_right_led_3_off();
 
-  uint8_t msg[RAW_EPSIZE];
+  uint8_t msg[RAW_EPSIZE] = { 0 };
   sprintf((char *)msg, "LAYER:%u", layer);
   raw_hid_send(msg, RAW_EPSIZE);
 


### PR DESCRIPTION
Hey - I enjoyed the blog post. Was having a read of how you'd done the HID code and spotted a buffer overrun - if you've noticed garbled characters coming through to your python code, this is a likely culprit - it sends all 64 bytes of `msg`, even if `sprintf` only writes to 7 of them.

I have a feeling the `h.read(8)` on the python side can now drop to 7 too, since previously it would just read the `'\0'` that `sprintf` tacks on the end, although I don't know the semantics of the hid library, maybe it wants that nul byte? Maybe it doesn't. Let's find out together.

(depending on what version of C your compiler supports, there's also a way to assert the flip side - that the buffer is large enough, with `_Static_assert(sizeof(msg) >= 7);`)